### PR TITLE
Change return type of component to ReactElement

### DIFF
--- a/generate/helpers/content.sh
+++ b/generate/helpers/content.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 TEMPLATE_DIR="generate/templates"
-COMPONENT_IMPORT="import { Component } from '@/data/types'"
+COMPONENT_IMPORT="import { ReactElement } from 'react'"
 REACT_CHILDREN_IMPORT="import { ReactChildren } from '@/data/interfaces'"
 METADATA_IMPORT="import { Metadata } from 'next'"
 SERVICE_ERROR_IMPORT="import { ServiceError } from '@/data/errors'"
@@ -143,8 +143,8 @@ function create_layout() {
 
     if [ "$has_metadata" == "true" ]; then
         metadata_content=$(use_content_from_template "$main_name" "metadata" "partials")
-        final_content+="$METADATA_IMPORT"$'\n'
         final_content+="$COMPONENT_IMPORT"$'\n'
+        final_content+="$METADATA_IMPORT"$'\n'
         final_content+="$REACT_CHILDREN_IMPORT"$'\n\n'
         final_content+="$metadata_content"$'\n\n'
         final_content+="$layout_content"

--- a/generate/templates/component
+++ b/generate/templates/component
@@ -1,5 +1,5 @@
-import { Component } from '@/data/types'
+import { ReactElement } from 'react'
 
-export function {{MAIN_NAME}}(): Component {
+export function {{MAIN_NAME}}(): ReactElement {
     return <>{{MAIN_NAME}}</>
 }

--- a/generate/templates/error
+++ b/generate/templates/error
@@ -1,10 +1,12 @@
 'use client'
 
-import { useEffect } from 'react'
-import { Component } from '@/data/types'
+import { useEffect, ReactElement } from 'react'
 import { ErrorProps } from '@/data/interfaces'
 
-export default function {{MAIN_NAME}}Error({ error, reset }: ErrorProps): Component {
+export default function {{MAIN_NAME}}Error({ 
+    error,
+    reset 
+}: ErrorProps): ReactElement {
     useEffect(() => {
         console.error(error)
     }, [error])

--- a/generate/templates/layout
+++ b/generate/templates/layout
@@ -1,3 +1,3 @@
-export default function {{MAIN_NAME}}Layout({ children }: ReactChildren): Component {
+export default function {{MAIN_NAME}}Layout({ children }: ReactChildren): ReactElement {
     return <div>{children}</div>
 }

--- a/generate/templates/loading
+++ b/generate/templates/loading
@@ -1,5 +1,5 @@
-import { Component } from '@/data/types'
+import { ReactElement } from 'react'
 
-export default function {{MAIN_NAME}}Loading(): Component {
+export default function {{MAIN_NAME}}Loading(): ReactElement {
     return <>Loading...</>
 }

--- a/generate/templates/not-found
+++ b/generate/templates/not-found
@@ -1,7 +1,7 @@
+import { ReactElement } from 'react'
 import Link from 'next/link'
-import { Component } from '@/data/types'
 
-export default function {{MAIN_NAME}}NotFound(): Component {
+export default function {{MAIN_NAME}}NotFound(): ReactElement {
     return (
         <div>
             <h2>Not Found</h2>

--- a/src/app/browse/[id]/layout.tsx
+++ b/src/app/browse/[id]/layout.tsx
@@ -1,6 +1,8 @@
-import { Component } from '@/data/types'
+import { ReactElement } from 'react'
 import { ReactChildren } from '@/data/interfaces'
 
-export default function BrowseIdLayout({ children }: ReactChildren): Component {
+export default function BrowseIdLayout({
+    children
+}: ReactChildren): ReactElement {
     return <div>{children}</div>
 }

--- a/src/app/browse/[id]/page.tsx
+++ b/src/app/browse/[id]/page.tsx
@@ -1,5 +1,5 @@
-import { Component } from '@/data/types'
+import { ReactElement } from 'react'
 
-export default function BrowseIdPage(): Component {
+export default function BrowseIdPage(): ReactElement {
     return <>BrowseId</>
 }

--- a/src/app/browse/layout.tsx
+++ b/src/app/browse/layout.tsx
@@ -1,11 +1,13 @@
+import { ReactElement } from 'react'
 import { Metadata } from 'next'
-import { Component } from '@/data/types'
 import { ReactChildren } from '@/data/interfaces'
 
 export const metadata: Metadata = {
     title: 'Browse'
 }
 
-export default function BrowseLayout({ children }: ReactChildren): Component {
+export default function BrowseLayout({
+    children
+}: ReactChildren): ReactElement {
     return <div>{children}</div>
 }

--- a/src/app/browse/page.tsx
+++ b/src/app/browse/page.tsx
@@ -1,5 +1,5 @@
-import { Component } from '@/data/types'
+import { ReactElement } from 'react'
 
-export default function BrowsePage(): Component {
+export default function BrowsePage(): ReactElement {
     return <>Browse</>
 }

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,5 +1,5 @@
+import { ReactElement } from 'react'
 import { Metadata } from 'next'
-import { Component } from '@/data/types'
 import { ReactChildren } from '@/data/interfaces'
 
 export const metadata: Metadata = {
@@ -8,6 +8,6 @@ export const metadata: Metadata = {
 
 export default function DashboardLayout({
     children
-}: ReactChildren): Component {
+}: ReactChildren): ReactElement {
     return <div>{children}</div>
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,5 +1,5 @@
-import { Component } from '@/data/types'
+import { ReactElement } from 'react'
 
-export default function DashboardPage(): Component {
+export default function DashboardPage(): ReactElement {
     return <>Dashboard</>
 }

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,10 +1,12 @@
 'use client'
 
-import { useEffect } from 'react'
-import { Component } from '@/data/types'
+import { ReactElement, useEffect } from 'react'
 import { ErrorProps } from '@/data/interfaces'
 
-export default function GlobalError({ error, reset }: ErrorProps): Component {
+export default function GlobalError({
+    error,
+    reset
+}: ErrorProps): ReactElement {
     useEffect(() => {
         console.error(error)
     }, [error])

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
+import { ReactElement } from 'react'
 import { Metadata } from 'next'
 import { NextFont } from 'next/dist/compiled/@next/font'
 import { Inter } from 'next/font/google'
-import { Component } from '@/data/types'
 import { ReactChildren } from '@/data/interfaces'
 import './globals.css'
 
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
     description: 'Book recommendation app'
 }
 
-export default function RootLayout({ children }: ReactChildren): Component {
+export default function RootLayout({ children }: ReactChildren): ReactElement {
     return (
         <html lang='en'>
             <body className={inter.className}>{children}</body>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,7 +1,7 @@
+import { ReactElement } from 'react'
 import Link from 'next/link'
-import { Component } from '@/data/types'
 
-export default function RootNotFound(): Component {
+export default function RootNotFound(): ReactElement {
     return (
         <div>
             <h2>Not Found</h2>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
+import { ReactElement } from 'react'
 import Image from 'next/image'
-import { Component } from '@/data/types'
 
-export default function HomePage(): Component {
+export default function HomePage(): ReactElement {
     return (
         <main className='flex min-h-screen flex-col items-center justify-center'>
             <div className="relative flex gap-40 place-items-center before:absolute before:h-[300px] before:w-full sm:before:w-[480px] before:-translate-x-1/2 before:rounded-full before:bg-gradient-radial before:from-white before:to-transparent before:blur-2xl before:content-[''] after:absolute after:-z-20 after:h-[180px] after:w-full sm:after:w-[240px] after:translate-x-1/3 after:bg-gradient-conic after:from-sky-200 after:via-blue-200 after:blur-2xl after:content-[''] before:dark:bg-gradient-to-br before:dark:from-transparent before:dark:to-blue-700 before:dark:opacity-10 after:dark:from-sky-900 after:dark:via-[#0141ff] after:dark:opacity-40 before:lg:h-[360px] z-[-1]">

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -1,5 +1,5 @@
-import { Component } from '@/data/types'
+import { ReactElement } from 'react'
 
-export function Button(): Component {
+export function Button(): ReactElement {
     return <>Button</>
 }

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,5 +1,5 @@
-import { Component } from '@/data/types'
+import { ReactElement } from 'react'
 
-export function Footer(): Component {
+export function Footer(): ReactElement {
     return <>Footer</>
 }

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,5 +1,5 @@
-import { Component } from '@/data/types'
+import { ReactElement } from 'react'
 
-export function Header(): Component {
+export function Header(): ReactElement {
     return <>Header</>
 }

--- a/src/components/nav-bar.tsx
+++ b/src/components/nav-bar.tsx
@@ -1,5 +1,5 @@
-import { Component } from '@/data/types'
+import { ReactElement } from 'react'
 
-export function NavBar(): Component {
+export function NavBar(): ReactElement {
     return <>NavBar</>
 }

--- a/src/components/rating.tsx
+++ b/src/components/rating.tsx
@@ -1,5 +1,5 @@
-import { Component } from '@/data/types'
+import { ReactElement } from 'react'
 
-export function Rating(): Component {
+export function Rating(): ReactElement {
     return <>Rating</>
 }

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -1,7 +1,3 @@
-import { JSX } from 'react'
-
-export type Component = JSX.Element
-
 export type DigestError = Error & { digest?: string }
 
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'


### PR DESCRIPTION
## Changes

- Use ReactElement as return type for components
- Get rid of Component type
- Update generators

## Tickets

- [Replace component return type with ReactElement](https://trello.com/c/8lNalH6I)

## Checklist

- [x] Code linted
- [x] Tests pass (and new ones added if applicable)
- [x] Builds successfully
- [x] App functions properly
- [x] Screenshots provided (if applicable)
